### PR TITLE
デフォルトページ未設定の修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  get 'user/use'
+  root to 'user#use'
 
   get 'management_screen/show'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root to 'user#use'
+  root 'user#use'
 
   get 'management_screen/show'
 


### PR DESCRIPTION
routes.rbにrootが存在せず、デフォルトページが表示されてしまっていました。
そのため、デフォルトページとして期待されると思われる`user#use`をrootに変更しました。